### PR TITLE
[0.1.1] pull request for issue #16: fixed bug with invalid symbols in file names

### DIFF
--- a/lib/filename/validate.ex
+++ b/lib/filename/validate.ex
@@ -1,0 +1,19 @@
+defmodule DarkHand.File.Name.Validate do
+  def is_char_valid?(char) do
+    char |> String.at(0) |> String.match?(~r/^[\w.-]$/)
+  end
+
+  def correct_filename(file_name) do
+    file_name
+    |> String.to_charlist
+    |> Enum.map(
+      fn(element) ->
+        case is_char_valid?(<<element>>) do
+          true -> <<element>>
+          false -> "_"
+        end
+      end
+    )
+    |> List.to_string
+  end
+end

--- a/lib/http/httpstream.ex
+++ b/lib/http/httpstream.ex
@@ -1,5 +1,6 @@
 defmodule DarkHand.HTTP.HTTPStream do
   import DarkHand.HTTP.URL
+  import DarkHand.File.Name.Validate
   def get(url) do
     Stream.resource(
       fn -> httpoison_get(url) end,
@@ -49,7 +50,7 @@ defmodule DarkHand.HTTP.HTTPStream do
         IO.puts "[ERROR] Argument [#{url}] is not a URL or a downloadable resource. Refusing to download."
         System.halt(0)
       true ->
-        file_name = url |> Path.basename
+        file_name = url |> Path.basename |> correct_filename
         try do
           url
           |> get

--- a/test/unit/filename/validate_test.exs
+++ b/test/unit/filename/validate_test.exs
@@ -1,0 +1,39 @@
+defmodule DarkHand.Test.Unit.File.Name.Validate do
+  use ExUnit.Case
+  doctest DarkHand.File.Name.Validate
+  import DarkHand.File.Name.Validate
+
+  @tag :unit
+  @tag :unitfast
+  test "checks for file name correctness" do
+    assert is_char_valid?("_") == true
+    assert is_char_valid?("2") == true
+    assert is_char_valid?("k") == true
+    assert is_char_valid?("K") == true
+    assert is_char_valid?(".") == true
+    assert is_char_valid?("-") == true
+
+    assert is_char_valid?(" ") == false
+    assert is_char_valid?("[") == false
+    assert is_char_valid?("{") == false
+    assert is_char_valid?("/") == false
+    assert is_char_valid?("*") == false
+    assert is_char_valid?("?") == false
+    assert is_char_valid?("!") == false
+    assert is_char_valid?("|") == false
+    assert is_char_valid?(">") == false
+    assert is_char_valid?("<") == false
+    assert is_char_valid?("@") == false
+    assert is_char_valid?("#") == false
+  end
+
+  @tag :unit
+  @tag :unitfast
+  test "corrects invalid file names" do
+    assert correct_filename("a-correct_filename-3") == "a-correct_filename-3"
+    assert correct_filename("a-correct_filename-3.jpg") == "a-correct_filename-3.jpg"
+    assert correct_filename("a-cor@ect_fil?na=e-3.jpg") == "a-cor_ect_fil_na_e-3.jpg"
+    assert correct_filename("!@#$%^&*(){}[]  ") == "________________"
+    assert correct_filename("...jpg") == "...jpg"
+  end
+end


### PR DESCRIPTION
- Introduced module File.Name.Validate which scans file names for invalid symbols and replaces them with underscores.

Previously, it was possible to have temporary/intermittent files with filenames like `223ab3477?goto=download`. On filesystems like NTFS which forbid the use of special non-alphanumeric characters, such a file was impossible to create and therefore the download errored out.

After this pull request, all invalid symbols in file names now are substituted with underscores such that `223ab3477?goto=download` becomes `223ab3477_goto_download`, therefore the temporary files are now able to be created even on filesystems such as NTFS, because the only non-alphanumeric characters possible in a file name now are `_`, `-` and `.`